### PR TITLE
Change statement set_timeout return type

### DIFF
--- a/include/statement.hh
+++ b/include/statement.hh
@@ -38,6 +38,6 @@ public:
 
     statement &set_timeout(uint64_t timeout);
 
-    void reset(size_t arg_count);
+    statement &reset(size_t arg_count);
 };
 }  // namespace scmd

--- a/include/statement.hh
+++ b/include/statement.hh
@@ -36,7 +36,7 @@ public:
         return *this;
     }
 
-    void set_timeout(uint64_t timeout);
+    statement &set_timeout(uint64_t timeout);
 
     void reset(size_t arg_count);
 };

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -39,7 +39,8 @@ statement &statement::set_timeout(uint64_t timeout) {
     return *this;
 }
 
-void statement::reset(size_t arg_count) {
+statement &statement::reset(size_t arg_count) {
     scmd_internal::throw_on_cass_error(cass_statement_reset_parameters(_stmt, arg_count));
+    return *this;
 }
 }  // namespace scmd

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -34,8 +34,9 @@ CassStatement *statement::get_statement() {
     return _stmt;
 }
 
-void statement::set_timeout(uint64_t timeout) {
+statement &statement::set_timeout(uint64_t timeout) {
     scmd_internal::throw_on_cass_error(cass_statement_set_request_timeout(this->_stmt, timeout));
+    return *this;
 }
 
 void statement::reset(size_t arg_count) {


### PR DESCRIPTION
Instead of making it void, let it return a reference to the statement itself to allow for syntax such as:

```C++
scmd::statement stmt = ("SELECT * FROM blas.matrix_0;");
session->execute(stmt.set_timeout(0));
```

...rather than the unnecessarily drawn out:

```C++
scmd::statement stmt = ("SELECT * FROM blas.matrix_0;");
stmt.set_timeout(0);
session->execute(stmt);
```
